### PR TITLE
Add 10 minute sleep to infinite loops

### DIFF
--- a/SoxBot/admin-highlight.php
+++ b/SoxBot/admin-highlight.php
@@ -74,4 +74,7 @@ while(true) {
 			}
 		}
 	}
+
+	// Take a break before starting over
+	sleep( 600 );
 }

--- a/SoxBot/cratstats.php
+++ b/SoxBot/cratstats.php
@@ -186,5 +186,8 @@ while(true) {
 		initPage('Template:Cratstats')->edit($text, 'Posting status of Bureaucrat related areas. (BOT EDIT)');
 		$oldout = $text;
 	}
+
+	// Take a break before starting over
+	sleep( 600 );
 }
 ?>

--- a/SoxBot/datefix.php
+++ b/SoxBot/datefix.php
@@ -107,6 +107,9 @@ while(true) {
 			sleep(3);
 		}
 	}
+
+	// Take a break before starting over
+	sleep( 600 );
 }
 
 ?>

--- a/SoxBot/rfx-report.php
+++ b/SoxBot/rfx-report.php
@@ -92,6 +92,9 @@ while(true) {
 
 
     $reportbuffer = initPage( $output )->edit( $out, "Updating RFX Report, $numrfa RFAs, $numrfb RFBs" );
+
+	// Take a break before starting over
+	sleep( 600 );
 }
 
 function bailout($message) {

--- a/SoxBot/rfx-tally.php
+++ b/SoxBot/rfx-tally.php
@@ -57,4 +57,7 @@ while(true) {
 	unset( $open_rfxs );
 	unset( $open_rfx );
 	unset( $tallys );
+
+	// Take a break before starting over
+	sleep( 600 );
 }

--- a/SoxBot/status.php
+++ b/SoxBot/status.php
@@ -34,4 +34,7 @@ while(true) {
 	}
 
 	echo "Done\n\n";
+
+	// Take a break before starting over
+	sleep( 600 );
 }

--- a/SoxBot/taskchecker.php
+++ b/SoxBot/taskchecker.php
@@ -87,4 +87,7 @@ while(true) {
 		$wikiur->initPage("صارف:Cyberbot_I/Run/Adminstats")->edit($adminstatsur,"Setting task status to $adminstatsur.",true);
 		$oldadminstatsur = $adminstatsur;
 	}
+
+	// Take a break before starting over
+	sleep( 600 );
 }


### PR DESCRIPTION
During investigation of T128838 it was discovered that 30% of all edit
activity on Wikimedia wikis are null edits attributable to a small
number of bot accounts. Null edits are edits that do not change the
existing page content. @atdt investigated further and found that several
SoxBot scripts are using `while(true)` loops around their business
logic. This means that the scripts will do their work on the wikis and
then immediately start over to do the work again. The bot tasks are
important, but not so important that they should stress the Wikimedia
production servers and the Tool Labs servers by spinning in tight
infinite loops.

This patch introduces a 10 minute sleep to each `while(true)` loop to
reduce the frequency of operations from "as fast as the hardware and
software will support" to "approximately 144 times per day".
