### PR TITLE
Do nothing if user isn't a sysop

### DIFF
--- a/SoxBot/enwiki-adminstats.php
+++ b/SoxBot/enwiki-adminstats.php
@@ -45,13 +45,6 @@ foreach ($u as $name) {
 	if( $issysop ) {
 		process($m[2]);	
 	}
-	else {
-		$out = "'''$m[2] is not an administrator or an account creator.<br>Therefore they have been disallowed the use of adminstats.'''";
-		echo $out;
-		echo "\n";
-		$toedit = "Template:Adminstats/$m[2]";
-		initPage( $toedit )->edit($out,"Adminstats are not allowed for this user.",true);
-	}
 }
 
 mysqli_close( $db );


### PR DESCRIPTION
Should hopefully take care of some recent discussions about such adminstats for non-sysops (https://en.wikipedia.org/wiki/User_talk:Cyberpower678/Archive_58#Cyberbot_1_creating_adminstats_for_non-admin_users).  For editors who have never had the bit, no page will ever be created.  For editors who were once sysops, the bot would not overwrite their template.

Am I right in thinking that just removing this section would work?  Should quiet things down.

Ideally, the bot would also mark templates for former sysops as "former admin" or some thing akin to that.